### PR TITLE
Added the dynamic batch size to the JCAS and to the Annotator of Biofid

### DIFF
--- a/textimager-uima-biofid-flair/src/main/java/org/hucompute/textimager/uima/biofid/flair/BiofidFlair.java
+++ b/textimager-uima-biofid-flair/src/main/java/org/hucompute/textimager/uima/biofid/flair/BiofidFlair.java
@@ -1,5 +1,6 @@
 package org.hucompute.textimager.uima.biofid.flair;
 
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.MetaDataStringField;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import org.apache.uima.UimaContext;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
@@ -18,6 +19,8 @@ import org.texttechnologylab.annotation.type.Taxon;
 
 import java.util.ArrayList;
 import java.util.Collection;
+
+import static java.lang.Integer.parseInt;
 
 public class BiofidFlair extends RestAnnotatorParallel {
 	protected MappingProvider mappingProvider;
@@ -38,6 +41,24 @@ public class BiofidFlair extends RestAnnotatorParallel {
 		mappingProvider.setDefault(MappingProvider.LANGUAGE, "de");
 	}
 
+	/**
+	 * The unique key to identify the annotation of the dynamic batch size inside of the jCas Object
+	 */
+	static public String DYNAMIC_CONFIGURATION_BATCH_SIZE_KEY = "biofid_flair.dynamic_configuration.batch_size";
+
+	/**
+	 * Sets the batch size as annotation inside of the jCAS
+	 * @param aJCAS The jCAS Object to annotate
+	 * @param batch_size The batch size to write into the jCas Object
+	 */
+	public static void set_batch_size(JCas aJCAS, int batch_size) {
+		MetaDataStringField field = new MetaDataStringField(aJCAS);
+		field.setValue(Integer.toString(batch_size));
+		//Set the key to something constant
+		field.setKey(BiofidFlair.DYNAMIC_CONFIGURATION_BATCH_SIZE_KEY);
+		field.addToIndexes();
+	}
+
 	@Override
 	protected JSONObject buildJSON(JCas aJCas) {
 		// Format:
@@ -50,9 +71,23 @@ public class BiofidFlair extends RestAnnotatorParallel {
 				.map(Annotation::getCoveredText)
 				.forEach(sentences::put);
 
+		//Default batch size is 16
+		int batch_size = 16;
+
+		// Extract the batch size from the jCas if there is any
+		for (MetaDataStringField i : JCasUtil.select(aJCas, MetaDataStringField.class)) {
+			if (i.getKey().trim().equals(BiofidFlair.DYNAMIC_CONFIGURATION_BATCH_SIZE_KEY.trim())) {
+				batch_size = parseInt(i.getValue().trim());
+				if(batch_size > 128) {
+					batch_size = 128;
+				}
+			}
+		}
+
 		// Pack in "sentences" object
 		JSONObject payload = new JSONObject();
 		payload.put("sentences", sentences);
+		payload.put("batch_size",batch_size);
 
 		return payload;
 	}

--- a/textimager-uima-biofid-flair/src/test/java/org/hucompute/textimager/uima/biofid/flair/BiofidFlairTest.java
+++ b/textimager-uima-biofid-flair/src/test/java/org/hucompute/textimager/uima/biofid/flair/BiofidFlairTest.java
@@ -23,6 +23,7 @@ public class BiofidFlairTest {
         String sentence_str = "Das ist ein Test am 08.12.2020, einem Dienstag in Frankfurt.";
 
         JCas jCas = JCasFactory.createText(sentence_str + " " + sentence_str, "de");
+        BiofidFlair.set_batch_size(jCas,10);
 
         Sentence sentence1 = new Sentence(jCas, 0, sentence_str.length());
         sentence1.addToIndexes();


### PR DESCRIPTION
Added the capability do dynamically set batch size in the document and send this as parameter in the json to the annotator.