### PR TITLE
Upgraded insecure connections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		</repository>
 		<repository>
 			<id>ukp-oss-model-releases</id>
-			<url>http://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-model-releases-local</url>
+			<url>https://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-model-releases-local</url>
 		</repository>
 	</repositories>
 

--- a/textimager-uima-biofid-gazetteer/pom.xml
+++ b/textimager-uima-biofid-gazetteer/pom.xml
@@ -217,14 +217,14 @@
         <repository>
             <id>hu-central</id>
             <name>alba-releases</name>
-            <url>http://service.hucompute.org/artifactory/libs-snapshot-local</url>
+            <url>https://service.hucompute.org/artifactory/libs-snapshot-local</url>
         </repository>
         <repository>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
             <id>ukp-oss-model-releases</id>
-            <url>http://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-model-releases-local</url>
+            <url>https://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-model-releases-local</url>
         </repository>
         <repository>
             <id>jitpack.io</id>
@@ -236,12 +236,12 @@
         <repository>
             <id>hu-central</id>
             <name>alba-releases</name>
-            <url>http://service.hucompute.org/artifactory/libs-snapshot-local</url>
+            <url>https://service.hucompute.org/artifactory/libs-snapshot-local</url>
         </repository>
         <snapshotRepository>
             <id>hu-snapshots</id>
             <name>alba-snapshots</name>
-            <url>http://service.hucompute.org/artifactory/libs-snapshot-local</url>
+            <url>https://service.hucompute.org/artifactory/libs-snapshot-local</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
This commit fixes the problem of an insecure connection lying around while an secure one does work just as well. The configuration of maven on the github actions server prevent such an connection by blocking them. This should fix the issue on github actions.